### PR TITLE
Fix translation for `<`

### DIFF
--- a/quadrupler.py
+++ b/quadrupler.py
@@ -10,7 +10,7 @@ translation ={
 ",": ",<[-]<[-]<[-]>>>",
 ".": ".",
 ">": ">>>>>>",
-"<": ">>>>>>"
+"<": "<<<<<<"
 }
 def translate(program):
 	output = INIT + program


### PR DESCRIPTION
The original translation of `<` was mistakenly the same as that of `>`.